### PR TITLE
Removed agenda "The process around KQED Lab News 2.0"

### DIFF
--- a/public-media-potluck-january-2019.html
+++ b/public-media-potluck-january-2019.html
@@ -82,9 +82,7 @@
             <li>
               The Product Process -- testing and research, user testing, workflows, centralized knowledgebase, explaining product process.
             </li>
-            <li>
-              The process around KQED Lab News 2.0
-            </li>
+          
             <li>
               Demo: how KPCC deploys special editorial projects.
             </li>


### PR DESCRIPTION
This was supposed to be deleted before but accidentally snuck back in. This agenda item for Thu, Jan 17 was supposed to be removed per Tim Olson.