### PR TITLE
Add first batch of NPR Visuals tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,16 @@
           <p>Slimdown is a simple gem to allow you to easily add static pages to your app via a folder full of Markdown files. There is also a <a href="https://github.com/APMG/php-slimdown">PHP version</a> available.</p>
         </div>
 
+        <div class="listing">
+          <h3><a href="https://github.com/nprapps/interactive-template">NPR's Interactive Template</a> A comprehensive scaffolding for building interactive stories</h3>
+          <p>The Interactive Template provides a complete toolkit for building rich multimedia pages, fed from Google Sheets, Docs, CSV, JSON, and Markdown. Includes a live development server with utilities for bundling and compiling JavaScript and CSS (from LESS). Pages are deployed to Amazon S3.</p>
+        </div>
+
+        <div class="listing">
+          <h3><a href="https://github.com/nprapps/dailygraphics-next">Dailygraphics Next</a> A data visualization template from NPR Visuals</h3>
+          <p>The Dailygraphics rig is used by NPR to create data visualizations for stories using D3, powered by Google Sheets and published to S3. It includes a number of templates for different types of graphics, all of which are responsive and embeddable using Pym.js.</p>
+        </div>
+
       </div> <!--end Content Management Systems category -->
 
 
@@ -104,6 +114,11 @@
         <div class="listing">
           <h3><a href="https://github.com/APMG/oembed_proxy">oEmbed Proxy</a> Simple library to manage first party, embedly, and custom oembeds</h3>
           <p>At MPR/APM, producers want to include content from tons of third party systems. Many of these support <a href="https://oembed.com/">oEmbeds</a>, a spec for content embedding. To handle these, we built the oEmbed Proxy which is a single place to support first party oembeds (where the provider supports oembeds natively), Embed.ly oembeds (where they built support for a pile of additional content providers), and "Fauxembeds (where we build our own embed providers for sites which do not support it). The oEmbed Proxy is highly extensible and makes it easy to add additional oEmbed providers.</p>
+        </div>
+
+        <div class="listing">
+          <h3><a href="https://github.com/nprapps/lunchbox">Lunchbox</a> Utilities for creating social cards and embeds</h3>
+          <p>Lunchbox is a combination of several tools used at NPR for creating social media cards: a watermarking tool, quote card generator, and fact list image creator.</p>
         </div>
       </div> <!--end Social Media & 3rd Party Platforms category -->
 
@@ -121,6 +136,10 @@
       <div class="category">
         <hr>
         <h2>Design Systems</h2>
+        <div class="listing">
+          <h3><a href="https://training.npr.org/digital/take-our-playbook-nprs-guide-to-building-immersive-storytelling-projects/">Hypothesis-Driven Design</a> From NPR Visuals</h3>
+          <p>A guide to creating immersive storytelling projects on editorial teams, from conception to publication.</p>
+        </div>
       </div> <!--end Design Systems category -->
 
 


### PR DESCRIPTION
I'd also be happy to go through in a future PR and add some of the additional tools created outside of the public media ecosystem, such as the various embedding frameworks for working around CMS limitations, and other publications' standalone news app generators.